### PR TITLE
Using sumo/tools/randomTrips to generate trips

### DIFF
--- a/aienvs/Sumo/LDM.py
+++ b/aienvs/Sumo/LDM.py
@@ -433,7 +433,7 @@ class ldm():
         """
         index = 0
         for index in range(len(lights)):
-            if lights[index] == 'G':
+            if lights[index] == 'G' or lights[index] == 'g':
                 val = 0.8
             elif lights[index] == 'y':
                 val = 0.5

--- a/aienvs/Sumo/SumoGymAdapter.py
+++ b/aienvs/Sumo/SumoGymAdapter.py
@@ -34,6 +34,7 @@ class SumoGymAdapter(Env):
                 'resolutionInPixelsPerMeterX': 1,  # for the observable frame
                 'resolutionInPixelsPerMeterY': 1,  # for the observable frame
                 'y_t': 6,  # yellow time
+                'generate_conf': True,  # for automatic route/config generation
                 'trips_generate': False, #using sumo/tools/randomTrips.py to generate trips
                 'trips_generate_options': [], # sumo/tools/randomTrips.py additional options. -n, -o already handled!
 
@@ -45,7 +46,6 @@ class SumoGymAdapter(Env):
                 'route_max_segments' : 0,  #  for automatic route/config generation, ask Rolf
                 'route_ends' : [],  #  for automatic route/config generation, ask Rolf
 
-                'generate_conf' : True,  # for automatic route/config generation
                 'libsumo' : False,  # whether libsumo is used instead of traci
                 'waiting_penalty' : 1,  # penalty for waiting
                 'new_reward': False,  # some other type of reward ask Miguel

--- a/aienvs/Sumo/SumoGymAdapter.py
+++ b/aienvs/Sumo/SumoGymAdapter.py
@@ -34,12 +34,17 @@ class SumoGymAdapter(Env):
                 'resolutionInPixelsPerMeterX': 1,  # for the observable frame
                 'resolutionInPixelsPerMeterY': 1,  # for the observable frame
                 'y_t': 6,  # yellow time
+                'trips_generate': False, #using sumo/tools/randomTrips.py to generate trips
+                'trips_generate_options': [], # sumo/tools/randomTrips.py additional options. -n, -o already handled!
+
+                # Custom route and trip generation if trips_generate is set to False
                 'car_pr': 0.5,  # for automatic route/config generation probability that a car appears
                 'car_tm': 2,  #  for automatic route/config generation when the first car appears?
                 'route_starts' : [],  #  for automatic route/config generation, ask Rolf
                 'route_min_segments' : 0,  #  for automatic route/config generation, ask Rolf
                 'route_max_segments' : 0,  #  for automatic route/config generation, ask Rolf
                 'route_ends' : [],  #  for automatic route/config generation, ask Rolf
+
                 'generate_conf' : True,  # for automatic route/config generation
                 'libsumo' : False,  # whether libsumo is used instead of traci
                 'waiting_penalty' : 1,  # penalty for waiting

--- a/aienvs/Sumo/SumoGymAdapter.py
+++ b/aienvs/Sumo/SumoGymAdapter.py
@@ -45,14 +45,14 @@ class SumoGymAdapter(Env):
                 'route_min_segments' : 0,  #  for automatic route/config generation, ask Rolf
                 'route_max_segments' : 0,  #  for automatic route/config generation, ask Rolf
                 'route_ends' : [],  #  for automatic route/config generation, ask Rolf
+                'seed': None,
 
                 'libsumo' : False,  # whether libsumo is used instead of traci
                 'waiting_penalty' : 1,  # penalty for waiting
                 'new_reward': False,  # some other type of reward ask Miguel
                 'lightPositions' : {},  # specify traffic light positions
                 'scaling_factor' : 1.0,  # for rescaling the reward? ask Miguel
-                'maxConnectRetries':50,  # maximum reattempts to connect by Traci
-                'seed': None
+                'maxConnectRetries':50  # maximum reattempts to connect by Traci
                 }
 
     def __init__(self, parameters:dict={}):

--- a/aienvs/Sumo/SumoHelper.py
+++ b/aienvs/Sumo/SumoHelper.py
@@ -166,9 +166,8 @@ class SumoHelper(object):
                               " a bug.".format(expected_value, car_sum))
 
     def __del__(self):
-        print('deleting')
-        # if(self.parameters['generate_conf']):
-        #     if ('sumocfg_file' in locals()):
-        #         os.remove(self.sumocfg_file)
-        #     if ('_route_file' in locals()):
-        #         os.remove(self._route_file)
+        if(self.parameters['generate_conf']):
+            if ('sumocfg_file' in locals()):
+                os.remove(self.sumocfg_file)
+            if ('_route_file' in locals()):
+                os.remove(self._route_file)

--- a/aienvs/Sumo/SumoHelper.py
+++ b/aienvs/Sumo/SumoHelper.py
@@ -38,9 +38,12 @@ class SumoHelper(object):
         Checks if the scenario is well-defined and usable by seeing if all
         the needed files exist.
         """
-        dirname = os.path.dirname(__file__)
-        sumoai_home = os.path.join(dirname, "../..")
-        self.scenario_path = os.path.join(sumoai_home, 'scenarios/Sumo', scenario)
+        if 'scenarios_folder' not in self.parameters:
+            dirname = os.path.dirname(__file__)
+            sumoai_home = os.path.join(dirname, "../..")
+            self.scenario_path = os.path.join(sumoai_home, 'scenarios/Sumo', scenario)
+        else:
+            self.scenario_path = os.path.join(self.parameters['scenarios_folder'], scenario)
 
         if(self.parameters['generate_conf']):
             self._net_file = os.path.basename(glob.glob(self.scenario_path + '/*.net.xml')[0])

--- a/aienvs/Sumo/SumoHelper.py
+++ b/aienvs/Sumo/SumoHelper.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import warnings
 import xml.etree.ElementTree as ElementTree
 import glob
+import randomTrips
+
 
 
 class SumoHelper(object):
@@ -56,11 +58,10 @@ class SumoHelper(object):
 
         return True
 
-    def write_route(self, route_dict, car_list):
+    def write_route(self, route_file, route_dict, car_list):
         """
         Writes the route information and generated vehicles to file
         """
-
         # Define possible routes as read from file earlier
         setup_string = "<routes>\n\n"
 
@@ -69,8 +70,6 @@ class SumoHelper(object):
                             route_dict[route] + '"/>\n'
         setup_string += '\n'
 
-        route_name = str(self._port) + '_routes.rou.xml'
-        route_file = os.path.join(self.scenario_path, route_name)
         # Write the cars to file as generated earlier
         with open(route_file, 'w') as f:
             f.write(setup_string)
@@ -125,37 +124,51 @@ class SumoHelper(object):
         Generates vehicles for each possible route in the scenario and writes
         them to file. Returns the location of the sumocfg file.
         """
-        logging.debug(('The seed being used for route generation: {}'.format(seed)))
-        random.seed(seed)
 
-        car_list = []
-        car_sum = 0
+        route_name = str(self._port) + '_routes.rou.xml'
+        route_file = os.path.join(self.scenario_path, route_name)
+        net_file = os.path.join(self.scenario_path, self._net_file)
 
-        route_dict = {}
-        expected_value = self.parameters['car_tm'] * self.parameters['car_pr']
+        if self.parameters['trips_generate']:
+            logging.debug('Using sumo/tools/randomTrips.py to generate trips')
+            randomTrips.main(randomTrips.get_options(self.parameters['trips_generate_options'] +
+                                                     ['-n', net_file,
+                                                      '-o', route_file]))
 
-        for t in range(self.parameters['car_tm']):
-            random_number = random.randint(0, 100) * 0.01
-            if random_number < self.parameters['car_pr']:
-                route = self.generate_randomized_route()
-                key = str(len(route_dict) + 1)
-                route_dict[key] = route
-                car = key
-                car_list.append(car)
-                car_sum += 1
-            else:
-                car_list.append(None)
+        else:
+            logging.debug('Manually creating trips based on provided segments')
+            logging.debug(('The seed being used for route generation: {}'.format(seed)))
+            random.seed(seed)
 
-        self.write_route(route_dict, car_list)
+            car_list = []
+            car_sum = 0
 
-        if float(car_sum) / expected_value >= 10:
-            warnings.warn("The expected number of cars is {}, but the "
-                          "actual number of cars is {}, which may indicate"
-                          " a bug.".format(expected_value, car_sum))
+            route_dict = {}
+            expected_value = self.parameters['car_tm'] * self.parameters['car_pr']
+
+            for t in range(self.parameters['car_tm']):
+                random_number = random.randint(0, 100) * 0.01
+                if random_number < self.parameters['car_pr']:
+                    route = self.generate_randomized_route()
+                    key = str(len(route_dict) + 1)
+                    route_dict[key] = route
+                    car = key
+                    car_list.append(car)
+                    car_sum += 1
+                else:
+                    car_list.append(None)
+
+            self.write_route(route_file, route_dict, car_list)
+
+            if float(car_sum) / expected_value >= 10:
+                warnings.warn("The expected number of cars is {}, but the "
+                              "actual number of cars is {}, which may indicate"
+                              " a bug.".format(expected_value, car_sum))
 
     def __del__(self):
-        if(self.parameters['generate_conf']):
-            if ('sumocfg_file' in locals()):
-                os.remove(self.sumocfg_file)
-            if ('_route_file' in locals()):
-                os.remove(self._route_file)
+        print('deleting')
+        # if(self.parameters['generate_conf']):
+        #     if ('sumocfg_file' in locals()):
+        #         os.remove(self.sumocfg_file)
+        #     if ('_route_file' in locals()):
+        #         os.remove(self._route_file)


### PR DESCRIPTION
**Allows using sumo/tools/randomTrips .py to generate trips**. Ignores following parameters if `'trips_generate` is set to True:
```
'car_pr': 0.5,  # for automatic route/config generation probability that a car appears
'car_tm': 2,  #  for automatic route/config generation when the first car appears?
'route_starts' : [],  #  for automatic route/config generation, ask Rolf
'route_min_segments' : 0,  #  for automatic route/config generation, ask Rolf
'route_max_segments' : 0,  #  for automatic route/config generation, ask Rolf
'route_ends' : [],  #  for automatic route/config generation, ask Rolf
'seed': None
```

**Fixes an issue with 'g' in traffic phases**
For most custom scenario imported using osmWebWizard there are also some phases for traffic lights that are 'g' instead of 'G'. This has something to do with lane priority. The wrapper sometimes crashes when it finds a 'g' in a phase. This is fixed in this branch.